### PR TITLE
Escape backslash in `:\' regexp

### DIFF
--- a/.purple/smileys/EAP/theme
+++ b/.purple/smileys/EAP/theme
@@ -1610,7 +1610,7 @@ skype/1208.gif	(hollest)
 ../EAP/facebook/sunglasses+emoticon.png	8| B| 8-| B-| 
 ../EAP/facebook/grumpy+emoticon.png	>:( >:-(
 ../EAP/facebook/pacman+emoticon.png	:v
-../EAP/facebook/unsure+emoticon.png	:/ :\ :-/ :-\
+../EAP/facebook/unsure+emoticon.png	:/ :\\ :-/ :-\
 ../EAP/facebook/curly+lips+emoticon.png	:3
 ../EAP/facebook/facebook-blush-emoticon.png	☺
 
@@ -2123,7 +2123,7 @@ skype/1208.gif	(hollest)
 ../EAP/facebook/sunglasses+emoticon.png	8| B| 8-| B-| 
 ../EAP/facebook/grumpy+emoticon.png	>:( >:-(
 ../EAP/facebook/pacman+emoticon.png	:v
-../EAP/facebook/unsure+emoticon.png	:/ :\ :-/ :-\
+../EAP/facebook/unsure+emoticon.png	:/ :\\ :-/ :-\
 ../EAP/facebook/curly+lips+emoticon.png	:3
 ../EAP/facebook/facebook-blush-emoticon.png	☺
 
@@ -2633,7 +2633,7 @@ skype/1208.gif	(hollest)
 #hangout/emoji_u1f62f.png	 😯 
 #hangout/emoji_u1f610.png	 😐 	:-| 	:| 	=|
 #hangout/emoji_u1f611.png	 😑 	-_-
-#hangout/emoji_u1f615.png	 😕 	:\ 	:/ 	:-\ 	:-/ 	=\ 	=/
+#hangout/emoji_u1f615.png	 😕 	:\\ 	:/ 	:-\ 	:-/ 	=\ 	=/
 #hangout/emoji_u1f620.png	 😠 
 #hangout/emoji_u1f62c.png	 😬 
 #hangout/emoji_u1f621.png	 😡 	>.<  	>:( 	>:-( 	>=(

--- a/.purple/smileys/facebook/theme
+++ b/.purple/smileys/facebook/theme
@@ -21,7 +21,7 @@ Author=mehdevil, Hernou L.
 ../EAP/facebook/sunglasses+emoticon.png	8| B| 8-| B-| 
 ../EAP/facebook/grumpy+emoticon.png	>:( >:-(
 ../EAP/facebook/pacman+emoticon.png	:v
-../EAP/facebook/unsure+emoticon.png	:/ :\ :-/ :-\
+../EAP/facebook/unsure+emoticon.png	:/ :\\ :-/ :-\
 ../EAP/facebook/curly+lips+emoticon.png	:3
 ../EAP/facebook/facebook-blush-emoticon.png	☺
 

--- a/.purple/smileys/hangout/theme
+++ b/.purple/smileys/hangout/theme
@@ -21,7 +21,7 @@ Author= Hernou L.
 ../EAP/hangout/emoji_u1f62f.png	 😯 
 ../EAP/hangout/emoji_u1f610.png	 😐 	:-| 	:| 	=|
 ../EAP/hangout/emoji_u1f611.png	 😑 	-_-
-../EAP/hangout/emoji_u1f615.png	 😕 	:\ 	:/ 	:-\ 	:-/ 	=\ 	=/
+../EAP/hangout/emoji_u1f615.png	 😕 	:\\ 	:/ 	:-\ 	:-/ 	=\ 	=/
 ../EAP/hangout/emoji_u1f620.png	 😠 
 ../EAP/hangout/emoji_u1f62c.png	 😬 
 ../EAP/hangout/emoji_u1f621.png	 😡 	>.<  	>:( 	>:-( 	>=(


### PR DESCRIPTION
With Facebook and Hangout themes, `:` (colon followed by a space) is replaced by an emoticon because in theme files the backslash in `:\` regexps is not properly escaped.  This patch fixes the bug.
