### PR TITLE
Replace regional indicator symbol combinations with flags, if available.

### DIFF
--- a/.purple/smileys/hangout/theme
+++ b/.purple/smileys/hangout/theme
@@ -616,16 +616,16 @@ Author= .H.
 ../EAP/hangout/emoji_u1f48e.png	 💎 
 ../EAP/hangout/emoji_u1f490.png	 💐 
 ../EAP/hangout/emoji_u1f492.png	 💒 
-../EAP/hangout/emoji_ufe4e5.png	 󾓥 
-../EAP/hangout/emoji_ufe4e6.png	 󾓦 
-../EAP/hangout/emoji_ufe4e7.png	 󾓧 
-../EAP/hangout/emoji_ufe4e8.png	 󾓨 
-../EAP/hangout/emoji_ufe4e9.png	 󾓩 
-../EAP/hangout/emoji_ufe4ea.png	 󾓪 
-../EAP/hangout/emoji_ufe4eb.png	 󾓫 
-../EAP/hangout/emoji_ufe4ec.png	 󾓬 
-../EAP/hangout/emoji_ufe4ed.png	 󾓭 
-../EAP/hangout/emoji_ufe4ee.png	 󾓮 
+../EAP/hangout/emoji_ufe4e5.png	 󾓥 🇯🇵
+../EAP/hangout/emoji_ufe4e6.png	 󾓦 🇺🇸
+../EAP/hangout/emoji_ufe4e7.png	 󾓧 🇫🇷
+../EAP/hangout/emoji_ufe4e8.png	 󾓨 🇩🇪
+../EAP/hangout/emoji_ufe4e9.png	 󾓩 🇮🇹
+../EAP/hangout/emoji_ufe4ea.png	 󾓪 🇬🇧
+../EAP/hangout/emoji_ufe4eb.png	 󾓫 🇪🇸
+../EAP/hangout/emoji_ufe4ec.png	 󾓬 🇷🇺
+../EAP/hangout/emoji_ufe4ed.png	 󾓭 🇨🇳
+../EAP/hangout/emoji_ufe4ee.png	 󾓮 🇰🇷
 ../EAP/hangout/emoji_u1f51d.png	 🔝 
 ../EAP/hangout/emoji_u1f519.png	 🔙 
 ../EAP/hangout/emoji_u1f51b.png	 🔛 


### PR DESCRIPTION
This adds regional indicator symbol combinations (country codes) to the existing flag entries. 
There are only ten flags, so the rest won't appear properly. A possible solution to that would be to borrow the flags of another pack for the ones that aren't available, that way you'd at least have a graphical representation. On the other hand, you'd have two different styles of flags, which isn't exactly pretty either.
Also, the default when you select a flag from the Smile! dialog is still the old symbol, which seem to be the countries' Chinese names. Making the regional indicator symbols the default would make most sense, as on other platforms you'll just see Chinese characters. 
I left this the way it was now, but I'm happy to push a commit that makes my addition the default.

Result:
![Chatlog Example](http://abload.de/img/screenshotfrom2017-074mu8v.png)